### PR TITLE
Adaptation for Redmine-2.5 (no "match" route):

### DIFF
--- a/app/views/user/_pretend_to.html.erb
+++ b/app/views/user/_pretend_to.html.erb
@@ -1,4 +1,4 @@
-<%= link_to l(:button_pretend), pretend_to_path(@user), :class => 'icon' if !session[:real_user_id] && User.current.admin? %>
+<%= link_to l(:button_pretend), pretend_to_path(@user), :class => 'icon', :method => :post if !session[:real_user_id] && User.current.admin? %>
 
 
 

--- a/app/views/user/_unpretend.html.erb
+++ b/app/views/user/_unpretend.html.erb
@@ -1,6 +1,6 @@
 <% if session[:real_user_id] %>
   <div class="flash error">
     <%= l(:pretend_message) %> <%= User.find_by_id(User.active.find(session[:real_user_id])) %>
-    <%= link_to l(:button_unpretend), unpretend_path, :class => 'icon' %>
+    <%= link_to l(:button_unpretend), unpretend_path, :class => 'icon', :method => :post %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 if Rails::VERSION::MAJOR >= 3
   RedmineApp::Application.routes.draw do
-    match 'admin/pretend_to/:id' => 'application#pretend_to', :as => 'pretend_to'
-    match 'admin/unpretend' => 'application#unpretend', :as => 'unpretend'
+    post 'admin/pretend_to/:id' => 'application#pretend_to', :as => 'pretend_to'
+    post 'admin/unpretend' => 'application#unpretend', :as => 'unpretend'
   end
 else
   ActionController::Routing::Routes.draw do |map|


### PR DESCRIPTION
On Debian "Jessie" Redmine-2.5.2.devel fails to start with the following error:

```
An error occurred while loading the routes definition of redmine_pretend plugin (/usr/share/redmine/plugins/redmine_pretend/config/routes.rb):
You should not use the `match` method in your router without specifying an HTTP method.
If you want to expose your action to both GET and POST, add `via: [:get, :post]` option.
If you want to expose your action to GET, use `get` in the router:
  Instead of: match "controller#action"
  Do: get "controller#action".
Error when running rake db:migrate, check database configuration.
```
