### PR TITLE
Do not allow switch to user with admin permissions

### DIFF
--- a/app/helpers/pretend_helper.rb
+++ b/app/helpers/pretend_helper.rb
@@ -1,7 +1,11 @@
 module PretendHelper
   def can_user_pretend_to?(user)
     return false unless user.try(:id)
-    not_pretending? && User.current.admin? && User.current != user
+
+    not_pretending? &&
+      User.current.admin? &&
+      User.current != user &&
+      !user.admin?
   end
 
   private

--- a/lib/redmine_pretend/application_controller_patch.rb
+++ b/lib/redmine_pretend/application_controller_patch.rb
@@ -18,12 +18,13 @@ module PretendPatches
 
     module InstanceMethods
       def pretend_to
-        render_403 unless can_pretend?
+        return render_403 unless can_pretend?
 
-        if not pretending?
-          remember_current_user
+        unless pretending?
           user = User.find(params[:id])
+          return render_403 if user.admin?
 
+          remember_current_user
           logger.info "#{ User.current } is pretend as #{user}"
           set_user(user)
         end


### PR DESCRIPTION
I made some changes, that user can not switch to user with admin permissions. If there are more then one user with admin permissions, he/she would not like it, if someone else make changes with this credentials. It would be nice, if you can merge this change.